### PR TITLE
Delvis rollback av endringsstatus for å få åut kontraktsendringer.

### DIFF
--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/KnekkpunktUtleder.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/KnekkpunktUtleder.kt
@@ -25,9 +25,10 @@ internal object KnekkpunktUtleder {
         finnForIkkeOppfyltInngangsvilkår(knekkpunkMap, regelGrunnlag.inngangsvilkår)
         finnForPleiebehov(knekkpunkMap, regelGrunnlag.pleiebehov)
         finnForAnnenPartsUttaksplan(knekkpunkMap, regelGrunnlag.andrePartersUttaksplan)
-        if (regelGrunnlag.forrigeUttaksplan != null) {
-            finnForForrigeUttaksplan(knekkpunkMap, regelGrunnlag.forrigeUttaksplan)
-        }
+//ROLLBACK
+//        if (regelGrunnlag.forrigeUttaksplan != null) {
+//            finnForForrigeUttaksplan(knekkpunkMap, regelGrunnlag.forrigeUttaksplan)
+//        }
         finnForTilsynsperiode(knekkpunkMap, regelGrunnlag.tilsynsperioder)
         finnForArbeid(knekkpunkMap, regelGrunnlag.arbeid)
         finnForBeredskap(knekkpunkMap, regelGrunnlag.beredskapsperioder.keys)

--- a/server/src/main/kotlin/no/nav/pleiepengerbarn/uttak/server/UttakplanApi.kt
+++ b/server/src/main/kotlin/no/nav/pleiepengerbarn/uttak/server/UttakplanApi.kt
@@ -74,7 +74,8 @@ class UttakplanApi {
         if (forrigeUttaksplan != null) {
             uttaksplan = UttaksplanMerger.slåSammenUttaksplaner(forrigeUttaksplan, uttaksplan)
         }
-        uttaksplan = EndringsstatusOppdaterer.oppdater(forrigeUttaksplan, uttaksplan)
+//ROLLBACK
+//        uttaksplan = EndringsstatusOppdaterer.oppdater(forrigeUttaksplan, uttaksplan)
 
         if (lagre) {
             uttakRepository.lagre(uttaksgrunnlag.saksnummer, UUID.fromString(uttaksgrunnlag.behandlingUUID), regelGrunnlag, uttaksplan)

--- a/server/src/test/kotlin/no/nav/pleiepengerbarn/uttak/server/UttakplanApiTest.kt
+++ b/server/src/test/kotlin/no/nav/pleiepengerbarn/uttak/server/UttakplanApiTest.kt
@@ -188,12 +188,20 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
         lagGrunnlag(saksnummer, "2020-01-07/2020-01-12").opprettUttaksplan()
         val uttaksplan = lagGrunnlag(saksnummer, "2020-01-01/2020-01-20").opprettUttaksplan()
 
+        assertThat(uttaksplan.perioder).hasSize(4)
+        uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-01/2020-01-03"), endringsstatus = Endringsstatus.NY)
+        uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-06/2020-01-10"), endringsstatus = Endringsstatus.NY)
+        uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-13/2020-01-17"), endringsstatus = Endringsstatus.NY)
+        uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-20/2020-01-20"), endringsstatus = Endringsstatus.NY)
+        /*
+        //ROLLBACK
         assertThat(uttaksplan.perioder).hasSize(5)
         uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-01/2020-01-03"), endringsstatus = Endringsstatus.NY)
         uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-06/2020-01-06"), endringsstatus = Endringsstatus.NY)
         uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-07/2020-01-10"), endringsstatus = Endringsstatus.UENDRET)
         uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-13/2020-01-17"), endringsstatus = Endringsstatus.NY)
         uttaksplan.assertOppfylt(periode = LukketPeriode("2020-01-20/2020-01-20"), endringsstatus = Endringsstatus.NY)
+         */
     }
 
     @Test
@@ -430,7 +438,8 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
             Utfall.OPPFYLT -> {
                 assertThat(periodeInfo.årsaker).isEqualTo(setOf(oppfyltÅrsak))
                 assertThat(periodeInfo.uttaksgrad).isEqualByComparingTo(grad)
-                assertThat(periodeInfo.endringsstatus).isEqualTo(endringsstatus)
+//ROLLBACK
+//                assertThat(periodeInfo.endringsstatus).isEqualTo(endringsstatus)
                 gradPerArbeidsforhold.forEach { (arbeidsforhold, prosent) ->
                     val utbetalingsgrad = periodeInfo.utbetalingsgrader.first { it.arbeidsforhold == arbeidsforhold } .utbetalingsgrad
                     assertThat(utbetalingsgrad).isEqualByComparingTo(prosent)
@@ -452,7 +461,8 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
             Utfall.IKKE_OPPFYLT -> {
                 assertThat(periodeInfo.årsaker).isEqualTo(ikkeOppfyltÅrsaker)
                 assertThat(periodeInfo.knekkpunktTyper).isEqualTo(knekkpunktTyper)
-                assertThat(periodeInfo.endringsstatus).isEqualTo(endringsstatus)
+//ROLLBACK
+//                assertThat(periodeInfo.endringsstatus).isEqualTo(endringsstatus)
             }
             else -> fail("Perioden $periode er oppfylt")
         }


### PR DESCRIPTION
Ikke merge denne inn før vi eventuelt vet at vi må rulle tilbake.