### PR TITLE
Bugfix. Rettet feil ifm utleding av endring annen part. Return i any(…

### DIFF
--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/UtledAndrePartersTilsyn.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/UtledAndrePartersTilsyn.kt
@@ -34,7 +34,7 @@ internal fun RegelGrunnlag.finnAndreSøkeresTilsyn(periode: LukketPeriode): Pair
 private fun Map<UUID, Uttaksplan>.endret(periode: LukketPeriode, sjekkSøkersVerdi: (UttaksperiodeInfo) -> Boolean): Boolean {
     return this.any { (_, uttaksplan) ->
         val periodeInfo = uttaksplan.finnOverlappendeUttaksperiode(periode)
-        return periodeInfo != null && sjekkSøkersVerdi(periodeInfo)
+        periodeInfo != null && sjekkSøkersVerdi(periodeInfo)
     }
 }
 


### PR DESCRIPTION
…som er en inline) function avbryter ved første element.