### PR TITLE
TSF-2224: Slår nå sammen perioder som har forskjellig knekkpunktTyper…

### DIFF
--- a/server/src/test/kotlin/no/nav/pleiepengerbarn/uttak/server/UttaksplanExtTest.kt
+++ b/server/src/test/kotlin/no/nav/pleiepengerbarn/uttak/server/UttaksplanExtTest.kt
@@ -10,12 +10,15 @@ import java.time.LocalDate
 internal class UttaksplanExtTest {
 
     @Test
-    internal fun `Bare helg mellom to datoer`() {
-        assertThat(bareHelgMellom(LocalDate.parse("2021-08-06"), LocalDate.parse("2021-08-09"))).isTrue
-        assertThat(bareHelgMellom(LocalDate.parse("2021-08-05"), LocalDate.parse("2021-08-09"))).isFalse
-        assertThat(bareHelgMellom(LocalDate.parse("2021-08-06"), LocalDate.parse("2021-08-10"))).isFalse
-        assertThat(bareHelgMellom(LocalDate.parse("2021-08-05"), LocalDate.parse("2021-08-10"))).isFalse
-        assertThat(bareHelgMellom(LocalDate.parse("2021-08-07"), LocalDate.parse("2021-08-10"))).isFalse
+    internal fun `Bare helg eller ingen dager mellom to datoer`() {
+        assertThat(bareHelgEllerIngenDagerMellom(LocalDate.parse("2021-08-06"), LocalDate.parse("2021-08-09"))).isTrue
+        assertThat(bareHelgEllerIngenDagerMellom(LocalDate.parse("2021-08-05"), LocalDate.parse("2021-08-09"))).isFalse
+        assertThat(bareHelgEllerIngenDagerMellom(LocalDate.parse("2021-08-06"), LocalDate.parse("2021-08-10"))).isFalse
+        assertThat(bareHelgEllerIngenDagerMellom(LocalDate.parse("2021-08-05"), LocalDate.parse("2021-08-10"))).isFalse
+        assertThat(bareHelgEllerIngenDagerMellom(LocalDate.parse("2021-08-07"), LocalDate.parse("2021-08-10"))).isFalse
+
+        assertThat(bareHelgEllerIngenDagerMellom(LocalDate.parse("2021-11-15"), LocalDate.parse("2021-11-16"))).isTrue
+        assertThat(bareHelgEllerIngenDagerMellom(LocalDate.parse("2021-11-15"), LocalDate.parse("2021-11-17"))).isFalse
     }
 
     @Test


### PR DESCRIPTION
…. Dette er løst ved at knekkpunkterTyper fjerners dersom perioder skal slås sammen. Fjern også begrensning som gjør at bare perioder over helg kan slås sammen.