### PR TITLE
Tilkommet arbeidsforhold skal påvirke uttaksgraden for gamle regler

### DIFF
--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/ArbeidExt.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/ArbeidExt.kt
@@ -10,7 +10,8 @@ import java.time.Duration
 import java.time.LocalDate
 
 internal fun Map<Arbeidsforhold, ArbeidsforholdPeriodeInfo>.finnSøkersTapteArbeidstid(
-    skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper: Boolean
+    skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper: Boolean,
+    nyeReglerGjelder: Boolean
 ): Prosent {
     var sumJobberNå = Duration.ZERO
     var sumJobberNormalt = Duration.ZERO
@@ -18,11 +19,11 @@ internal fun Map<Arbeidsforhold, ArbeidsforholdPeriodeInfo>.finnSøkersTapteArbe
         this.filter {
             Arbeidstype.values()
                 .find { arbeidstype -> arbeidstype.kode == it.key.type } !in GRUPPE_SOM_SKAL_SPESIALHÅNDTERES
-                    && it.value.tilkommet != true
+                    && (it.value.tilkommet != true || !nyeReglerGjelder)
         }
     } else {
         this.filter {
-            it.value.tilkommet != true
+            it.value.tilkommet != true || !nyeReglerGjelder
         }
     }
     oppdatertArbeid.values.forEach {

--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGrader.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGrader.kt
@@ -17,7 +17,7 @@ internal object BeregnGrader {
                 beregnGraderGrunnlag.nyeReglerUtbetalingsgrad
             )
         val søkersTapteArbeidstid =
-            beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper)
+            beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper, gjelderNyeRegler(beregnGraderGrunnlag))
         val uttaksgradResultat = avklarUttaksgrad(
             beregnGraderGrunnlag,
             etablertTilsynsprosent,
@@ -110,6 +110,7 @@ internal object BeregnGrader {
         beregnGraderGrunnlag: BeregnGraderGrunnlag,
         maksGradIProsent: Prosent
     ): GraderBeregnet {
+        val nyeReglerGjelder = gjelderNyeRegler(beregnGraderGrunnlag)
         val etablertTilsynsprosent = finnEtablertTilsynsprosent(beregnGraderGrunnlag.etablertTilsyn)
         val skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper =
             beregnGraderGrunnlag.arbeid.seBortFraAndreArbeidsforhold(
@@ -117,7 +118,10 @@ internal object BeregnGrader {
                 beregnGraderGrunnlag.nyeReglerUtbetalingsgrad
             )
         val søkersTapteArbeidstid =
-            beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper)
+            beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(
+                skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper,
+                nyeReglerGjelder
+            )
         val ønsketUttaksgradProsent = finnØnsketUttaksgradProsent(beregnGraderGrunnlag.oppgittTilsyn);
         val ønsketUttaksgrad = minOf(ønsketUttaksgradProsent, maksGradIProsent)
         val uttaksgradResultat = avklarUttaksgrad(
@@ -155,6 +159,12 @@ internal object BeregnGrader {
         )
     }
 
+    private fun gjelderNyeRegler(beregnGraderGrunnlag: BeregnGraderGrunnlag): Boolean {
+        val nyeReglerGjelder = beregnGraderGrunnlag.nyeReglerUtbetalingsgrad != null
+                && !beregnGraderGrunnlag.periode.fom.isBefore(beregnGraderGrunnlag.nyeReglerUtbetalingsgrad)
+        return nyeReglerGjelder
+    }
+
     private fun avklarUttaksgrad(
         beregnGraderGrunnlag: BeregnGraderGrunnlag,
         etablertTilsynprosent: Prosent,
@@ -167,7 +177,10 @@ internal object BeregnGrader {
                 beregnGraderGrunnlag.nyeReglerUtbetalingsgrad
             )
         val søkersTapteArbeidstid =
-            beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper)
+            beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(
+                skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper,
+                gjelderNyeRegler(beregnGraderGrunnlag)
+            )
 
         val restTilSøker =
             finnRestTilSøker(
@@ -201,7 +214,10 @@ internal object BeregnGrader {
 
         if (skalSeBortIfraArbeidstidFraSpesialhåndterteArbeidtyper) {
             val søkersTapteArbeidstidUtenAndreArbeidsforhold =
-                beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(true)
+                beregnGraderGrunnlag.arbeid.finnSøkersTapteArbeidstid(
+                    true,
+                    gjelderNyeRegler(beregnGraderGrunnlag)
+                )
             if (søkersTapteArbeidstidUtenAndreArbeidsforhold < TJUE_PROSENT) {
                 return UttaksgradResultat(
                     restTilSøker,


### PR DESCRIPTION
Før mai 2023 blei uttaksgraden påvirket av nye arbeidsforhold (tilkomne). Uttaksgraden til KUN_YTELSE og IKKE_YRKESAKTIV var satt opp til å speile uttaksgraden fra alle arbeidsforhold, også tilkomne. I mai 2023 blei det gjort ein endring som gjorde at tilkomne arbeidsforhold ikkje påvirket uttaksgraden. Dette førte til endring når gamle saker tas opp til revurdering. Denne endringen burde være avhengig av dato for nye regler siden det ellers vil føre til uriktig avslag for gamle saker der vi har tilkommet arbeidsforhold sammen med KUN_YTELSE.