### PR TITLE
TSFF-1099 Overstyr perioder dekket

### DIFF
--- a/kontrakter/src/main/kotlin/no/nav/pleiepengerbarn/uttak/kontrakter/Uttaksgrunnlag.kt
+++ b/kontrakter/src/main/kotlin/no/nav/pleiepengerbarn/uttak/kontrakter/Uttaksgrunnlag.kt
@@ -60,11 +60,17 @@ data class UtenlandsoppholdInfo(
     @JsonProperty("landkode") val landkode: String?
 )
 
+/** Overstyring av uttak
+ * overstyrtUttaksgrad bestemmer hvilken pleiepengegrad som skal settes på perioden
+ * skalUttaksgradOverstyreTimerDekket bestemmer om den overstyrte uttaksgraden skal gi endring i antall timer som dekkes og videre påvirke utbetalingsgradene for hver aktivitet
+ * overstyrtUtbetalingsgradPerArbeidsforhold overstyrer utbetalingsgrader per aktivitet. Dersom denne er satt for en aktivitet overstyrer dette det som regnes ut fra timer som dekkes. Dette gjelder også dersom skalUttaksgradOverstyreTimerDekket er satt til true
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 data class OverstyrtInput(
     @JsonProperty("overstyrtUttaksgrad") val overstyrtUttaksgrad: BigDecimal?,
+    @JsonProperty("skalUttaksgradOverstyreTimerDekket") val skalUttaksgradOverstyreTimerDekket: Boolean?,
     @JsonProperty("overstyrtUtbetalingsgradPerArbeidsforhold") val overstyrtUtbetalingsgradPerArbeidsforhold: List<OverstyrtUtbetalingsgradPerArbeidsforhold>,
 )
 

--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/ArbeidExt.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/ArbeidExt.kt
@@ -59,7 +59,7 @@ internal fun Map<Arbeidsforhold, ArbeidsforholdPeriodeInfo>.finnSøkersTapteArbe
 
 private fun ArbeidsforholdPeriodeInfo.ikkeFravær() = jobberNormalt <= jobberNå
 
-internal fun Map<Arbeidsforhold, ArbeidsforholdPeriodeInfo>.harSpesialhåndteringstilfelle(periode: LukketPeriode, nyeReglerUtbetalingsgrad: LocalDate?): Boolean {
+internal fun Map<Arbeidsforhold, ArbeidsforholdPeriodeInfo>.harSpesialhåndteringstilfelleForGamleRegler(periode: LukketPeriode, nyeReglerUtbetalingsgrad: LocalDate?): Boolean {
     val harSpesialhåndteringAktivitetstyper = any {
         Arbeidstype.values()
             .find { arbeidstype -> arbeidstype.kode == it.key.type } in GRUPPE_SOM_SKAL_SPESIALHÅNDTERES

--- a/regler/src/test/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGraderTest.kt
+++ b/regler/src/test/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGraderTest.kt
@@ -119,7 +119,7 @@ internal class BeregnGraderTest {
                 periode = PERIODE,
                 nyeReglerUtbetalingsgrad = NYE_REGLER_UTBETALINGSGRAD_DATO,
                 inntektsgradering = Inntektsgradering(BigDecimal.valueOf(50)),
-                overstyrtInput = OverstyrtInput(BigDecimal.valueOf(30), listOf(OverstyrtUtbetalingsgradPerArbeidsforhold(BigDecimal.valueOf(30), ARBEIDSGIVER1)))
+                overstyrtInput = OverstyrtInput(BigDecimal.valueOf(30), null, listOf(OverstyrtUtbetalingsgradPerArbeidsforhold(BigDecimal.valueOf(30), ARBEIDSGIVER1)))
             )
         )
 
@@ -127,6 +127,63 @@ internal class BeregnGraderTest {
             Årsak.OVERSTYRT_UTTAKSGRAD,
             BigDecimal.valueOf(30),
             ARBEIDSGIVER1 to BigDecimal.valueOf(30)
+        )
+        assertThat(grader.graderingMotTilsyn.overseEtablertTilsynÅrsak).isNull()
+        assertThat(grader.manueltOverstyrt).isTrue()
+    }
+
+    @Test
+    internal fun `Overstyring av uttaksgrad med endring av timer dekket`() {
+        val grader = BeregnGrader.beregn(
+            BeregnGraderGrunnlag(
+                pleiebehov = PROSENT_100,
+                etablertTilsyn = IKKE_ETABLERT_TILSYN,
+                andreSøkeresTilsyn = NULL_PROSENT,
+                andreSøkeresTilsynReberegnet = false,
+                arbeid = mapOf(
+                    ARBEIDSGIVER1 to ArbeidsforholdPeriodeInfo(jobberNormalt = FULL_DAG, jobberNå = INGENTING)
+                ),
+                ytelseType = YtelseType.PSB,
+                periode = PERIODE,
+                nyeReglerUtbetalingsgrad = null,
+                inntektsgradering = null,
+                overstyrtInput = OverstyrtInput(BigDecimal.valueOf(30), true, listOf())
+            )
+        )
+
+        grader.assert(
+            Årsak.OVERSTYRT_UTTAKSGRAD,
+            BigDecimal.valueOf(30),
+            ARBEIDSGIVER1 to BigDecimal.valueOf(30)
+        )
+        assertThat(grader.graderingMotTilsyn.overseEtablertTilsynÅrsak).isNull()
+        assertThat(grader.manueltOverstyrt).isTrue()
+    }
+
+    @Test
+    internal fun `Overstyring av uttaksgrad med endring av timer dekket og overstyring av utbetalingsgrad`() {
+        // Overstyring av utbetalingsgrad trumfer overstyring av timer dekket
+        val grader = BeregnGrader.beregn(
+            BeregnGraderGrunnlag(
+                pleiebehov = PROSENT_100,
+                etablertTilsyn = IKKE_ETABLERT_TILSYN,
+                andreSøkeresTilsyn = NULL_PROSENT,
+                andreSøkeresTilsynReberegnet = false,
+                arbeid = mapOf(
+                    ARBEIDSGIVER1 to ArbeidsforholdPeriodeInfo(jobberNormalt = FULL_DAG, jobberNå = INGENTING)
+                ),
+                ytelseType = YtelseType.PSB,
+                periode = PERIODE,
+                nyeReglerUtbetalingsgrad = null,
+                inntektsgradering = null,
+                overstyrtInput = OverstyrtInput(BigDecimal.valueOf(30), true, listOf(OverstyrtUtbetalingsgradPerArbeidsforhold(BigDecimal.valueOf(50), ARBEIDSGIVER1)))
+            )
+        )
+
+        grader.assert(
+            Årsak.OVERSTYRT_UTTAKSGRAD,
+            BigDecimal.valueOf(30),
+            ARBEIDSGIVER1 to BigDecimal.valueOf(50)
         )
         assertThat(grader.graderingMotTilsyn.overseEtablertTilsynÅrsak).isNull()
         assertThat(grader.manueltOverstyrt).isTrue()

--- a/server/src/test/kotlin/no/nav/pleiepengerbarn/uttak/server/UttakplanApiTest.kt
+++ b/server/src/test/kotlin/no/nav/pleiepengerbarn/uttak/server/UttakplanApiTest.kt
@@ -157,6 +157,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-01/2020-01-02") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = BigDecimal.ZERO,
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = BigDecimal.ZERO,
@@ -167,6 +168,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-03/2020-01-03") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = BigDecimal.valueOf(70),
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = BigDecimal.valueOf(
@@ -230,6 +232,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-01/2020-01-02") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = BigDecimal.valueOf(15),
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = BigDecimal.valueOf(15),
@@ -240,6 +243,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-03/2020-01-03") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = BigDecimal.valueOf(70),
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = BigDecimal.valueOf(
@@ -303,6 +307,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-09/2020-01-10") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = BigDecimal.valueOf(20),
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = HUNDRE_PROSENT, arbeidsforhold = ARBEIDSFORHOLD1
@@ -358,6 +363,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-09/2020-01-10") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = BigDecimal.valueOf(15),
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = HUNDRE_PROSENT, arbeidsforhold = ARBEIDSFORHOLD1
@@ -409,6 +415,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-06/2020-01-08") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = BigDecimal.ZERO,
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = BigDecimal.ZERO,
@@ -470,6 +477,7 @@ class UttakplanApiTest(@Autowired val restTemplate: TestRestTemplate) {
                 LukketPeriode("2020-01-06/2020-01-08") to
                         OverstyrtInput(
                             overstyrtUttaksgrad = null,
+                            skalUttaksgradOverstyreTimerDekket = null,
                             overstyrtUtbetalingsgradPerArbeidsforhold = listOf(
                                 OverstyrtUtbetalingsgradPerArbeidsforhold(
                                     overstyrtUtbetalingsgrad = BigDecimal.ZERO,


### PR DESCRIPTION
Behov:
I søskensaker ønsker vi at saksbehandler skal kunne redusere uttaksgraden dersom det allerede er uttak på et annet barn. Uttaksgraden må også påvirke utbetalingsgrader. I dag påvirker den overstyrte graden kun pleiepengegraden og utbetalingsgradene må settes manuelt.

Løsning
Legger til mulighet for å bestemme at den overstyrte uttaksgraden automatisk skal justere utbetalingsgradene for uttaksplanen ved at den endrer på timer som dekkes. Dersom det også er oppgitt overstyringer i utbetalingsgrader brukes dette.


