### PR TITLE
Filtrer ut arbeidsforhold uten tapt arbeid i  finnTotalNormalarbeidstid

### DIFF
--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnUtbetalingsgrader.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnUtbetalingsgrader.kt
@@ -101,6 +101,9 @@ object BeregnUtbetalingsgrader {
                 Arbeidstype.values().find { arbeidstype -> arbeidstype.kode == it.key.type })
         }.filter {
             it.value.tilkommet != true || !brukNyeRegler
+        }.filter {
+            it.value.taptArbeid(brukNyeRegler) > Duration.ZERO ||
+                Arbeidstype.entries.find { arbeidstype -> arbeidstype.kode == it.key.type } != Arbeidstype.ARBEIDSTAKER
         }.forEach {
             sumJobberNormalt1 += it.value.jobberNormalt
         }

--- a/regler/src/test/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGraderNyeReglerTest.kt
+++ b/regler/src/test/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGraderNyeReglerTest.kt
@@ -396,6 +396,38 @@ internal class BeregnGraderNyeReglerTest {
         )
     }
 
+    @Test
+    internal fun `AT uten fravær skal ikke blåse opp utbetalingsgraden til AT med fravær ved delvis uttaksgrad`() {
+        val grader = BeregnGrader.beregn(
+            BeregnGraderGrunnlag(
+                pleiebehov = PROSENT_100,
+                etablertTilsyn = IKKE_ETABLERT_TILSYN,
+                andreSøkeresTilsyn = Prosent(50),
+                andreSøkeresTilsynReberegnet = false,
+                arbeid = mapOf(
+                    ARBEIDSGIVER1 to ArbeidsforholdPeriodeInfo(
+                        jobberNormalt = FULL_DAG,
+                        jobberNå = FULL_DAG
+                    ),
+                    ARBEIDSGIVER2 to ArbeidsforholdPeriodeInfo(
+                        jobberNormalt = FULL_DAG,
+                        jobberNå = INGENTING
+                    )
+                ),
+                ytelseType = YtelseType.OLP,
+                periode = PERIODE,
+                virkningstidspunktRegelNyEllerBortfaltAktivitet = NYE_REGLER_UTBETALINGSGRAD_DATO,
+            )
+        )
+
+        grader.assert(
+            Årsak.AVKORTET_MOT_INNTEKT,
+            Prosent(50),
+            ARBEIDSGIVER1 to Prosent(0),
+            ARBEIDSGIVER2 to Prosent(50)
+        )
+    }
+
     private fun GraderBeregnet.assert(
         årsak: Årsak,
         uttaksgrad: Prosent,


### PR DESCRIPTION
### Behov / Bakgrunn

Dersom en behandling har flere AT-aktiviteter, summeres normalarbeidstid for alle disse, også de uten fravær. Når fordeling utregnes, baseres dette på tapt arbeidstid. Dette kan føre til høyere utbetalingsgrad enn tilsiktet.

Se [FAGSYSTEM-426846](https://jira.adeo.no/browse/FAGSYSTEM-426846) som eksempel: Her er det to aktvitieter med 27000 timer normalarbeidstid, og uttaksgrad på 50%. `sumJobberNormalt` blir da 54000. `timerSomDekkes` blir da, med 50% uttaksgrad, 27000. Når faktisk arbeidstid i den ene aktiviteten er 0 og den andre 27000, blir utbetalingsgrad 100%, selv om uttaksgrad er 50%

### Løsning

Filtrer ut arbeidsforhold uten tapt arbeid fra utregning av `timerSomDekkes`

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
