### PR TITLE
Hardkod restTilSøker til 100% for OLP-saker

### DIFF
--- a/nais/dev-fss-k9saksbehandling.yml
+++ b/nais/dev-fss-k9saksbehandling.yml
@@ -78,3 +78,5 @@ spec:
       value: "false"
     - name: IKKE_OVERSTYR_IKKE_OPPFYLT_PERIODE_REGEL
       value: "true"
+    - name: IKKE_REDUSER_UTTAK_VED_TILSYN_FOR_OLP
+      value: "true"

--- a/nais/prod-fss-k9saksbehandling.yml
+++ b/nais/prod-fss-k9saksbehandling.yml
@@ -76,3 +76,5 @@ spec:
     # Feature toggles
     - name: IKKE_OVERSTYR_IKKE_OPPFYLT_PERIODE_REGEL
       value: "false"
+    - name: IKKE_REDUSER_UTTAK_VED_TILSYN_FOR_OLP
+      value: "false"

--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGrader.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGrader.kt
@@ -187,7 +187,8 @@ internal object BeregnGrader {
                 beregnGraderGrunnlag.pleiebehov,
                 etablertTilsynprosent,
                 beregnGraderGrunnlag.andreSøkeresTilsyn,
-                beregnGraderGrunnlag.overseEtablertTilsynÅrsak
+                beregnGraderGrunnlag.overseEtablertTilsynÅrsak,
+                beregnGraderGrunnlag.ytelseType
             )
 
         val overstyrtUttak =
@@ -303,12 +304,16 @@ internal object BeregnGrader {
         pleiebehov: Pleiebehov,
         etablertTilsynsprosent: Prosent,
         andreSøkeresTilsyn: Prosent,
-        overseEtablertTilsynÅrsak: OverseEtablertTilsynÅrsak?
+        overseEtablertTilsynÅrsak: OverseEtablertTilsynÅrsak?,
+        ytelseType: YtelseType
     ): BigDecimal {
         if (pleiebehov == Pleiebehov.PROSENT_0) {
             return Prosent.ZERO
         }
         val pleiebehovprosent = pleiebehov.prosent
+        if (ytelseType == YtelseType.OLP) {
+            return pleiebehovprosent
+        }
         if (overseEtablertTilsynÅrsak != null) {
             return pleiebehovprosent - andreSøkeresTilsyn
         }

--- a/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGrader.kt
+++ b/regler/src/main/kotlin/no/nav/pleiepengerbarn/uttak/regler/BeregnGrader.kt
@@ -8,6 +8,10 @@ import java.time.Duration
 import java.time.LocalDate
 
 internal object BeregnGrader {
+    private var ikkeReduserUttakVedTilsynForOlp = false
+    init {
+        ikkeReduserUttakVedTilsynForOlp = System.getenv("IKKE_REDUSER_UTTAK_VED_TILSYN_FOR_OLP").toBoolean()
+    }
 
     internal fun beregn(beregnGraderGrunnlag: BeregnGraderGrunnlag): GraderBeregnet {
         val etablertTilsynsprosent = finnEtablertTilsynsprosent(beregnGraderGrunnlag.etablertTilsyn)
@@ -311,7 +315,7 @@ internal object BeregnGrader {
             return Prosent.ZERO
         }
         val pleiebehovprosent = pleiebehov.prosent
-        if (ytelseType == YtelseType.OLP) {
+        if (ikkeReduserUttakVedTilsynForOlp && ytelseType == YtelseType.OLP) {
             return pleiebehovprosent
         }
         if (overseEtablertTilsynÅrsak != null) {


### PR DESCRIPTION
### Behov / Bakgrunn

Dersom det finnes en PSB-sak med gradert tilsyn som overlapper med en OLP-sak, kan OLP-saken feilaktig få redusert uttaksgrad med årsak `GRADERT_MOT_TILSYN` ettersom `restTilSøker` (100% - etablert tilsyn for annen sak) blir lavere enn tapt arbeidstid, noe som ikke gir mening for OLP

### Løsning

`finnRestTilSøker` endres slik at den hardkodes slik at rest til søker ikke blir redusert for OLP-saker (og dermed blir 100%), og man ikke risikerer å få gradert uttak grunnet tilsyn

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
